### PR TITLE
Rework wait for magenetization based on input from Gazpachoking.

### DIFF
--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -783,8 +783,6 @@ class OutputDeluge(DelugePlugin):
                 @defer.inlineCallbacks
                 def _wait_for_metadata(id, timeout):
                     from time import sleep
-                    status_keys = ['files', 'total_size', 'save_path', 'move_on_completed_path',
-                                    'move_on_completed', 'progress']
                     log.info('Waiting %d seconds for "%s" to magnetize' % (timeout, entry['title']))
                     try:
                         while timeout > 0:

--- a/flexget/plugins/plugin_deluge.py
+++ b/flexget/plugins/plugin_deluge.py
@@ -790,17 +790,16 @@ class OutputDeluge(DelugePlugin):
                         while timeout > 0:
                             sleep(1)
                             status = yield client.core.get_torrent_status(id, ['files'])
-                            print status
                             if len(status['files']) > 0:
                                 log.info('"%s" magnetization successful' % (entry['title']))
-                                defer.returnValue(True)
+                                defer.returnValue(id)
                             else:
                                 timeout -= 1
                     except Exception as err:
                         log.error('wait_for_metadata Error: %s' % err)
 
                     log.warning('"%s" did not magnetize before the timeout elapsed, file list unavailable for processing.' % entry['title'])
-                    defer.returnValue(False)
+                    defer.returnValue(id)
 
                 def add_entry(entry, opts):
                     """Adds an entry to the deluge session"""


### PR DESCRIPTION
I've made some changes and did some testing based on comments from Gazpachoking. It seems to be functioning now with the following caveats:
- even though main_file_only has information regarding the files and sets files other than the main file to "do not download", the additional files still download. They show in the client as do not download but when the torrent is complete, the additional files are in the download directory.
- it DOES allow content_filename to function when main_file_only is specified

I've set this up with a subsequent move with clean_source task and it works well.

I've tested both cases where magnetization_timeout is both set and not set.
I've tested the case with a very short timeout (2 seconds) and validated the timeout expires and it continues on without file information as it does when the new timeout parameter is not set.

Thanks for the idea and initial function. It was fun to hack away at this. I'm not a python developer, so not really sure if there's anything here that should be cleaned up further, renamed for convention, more robust error handling, etc.
